### PR TITLE
Fix processDisclosureRequest to preserve unknown key/value pairs

### DIFF
--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -374,9 +374,8 @@ class Credentials {
    * @param     {Object}             response.doc
    */
   async processDisclosurePayload({ doc, payload }) {
-    console.log('processDisclosurePayload', payload)
     // Extract known key-value pairs from payload
-    const { own={}, capabilities=[], req, iat, exp, type, nad: mnid, dad: deviceKey, iss: did, boxPub, verified, ...rest } = payload
+    const { own={}, capabilities=[], aud, req, iat, exp, type, nad: mnid, dad: deviceKey, iss: did, boxPub, verified, ...rest } = payload
     const { uportProfile={} } = doc
 
     // Combine doc and payload into a single object, changing the names of some keys
@@ -386,15 +385,14 @@ class Credentials {
       ...own,
       ...uportProfile, 
       ...rest,
+      // aud, req, iat, exp are intentionally left out  
     }
+    
+    if (deviceKey) processed.deviceKey = deviceKey
 
     if (mnid) {
       processed.mnid = mnid
       processed.address = mnidDecode(mnid).address
-    }
-
-    if (deviceKey) {
-      processed.deviceKey = deviceKey
     }
 
     // Push notifications are the only supported capability at the moment

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -365,35 +365,51 @@ class Credentials {
 
   /**
    * Parse a selective disclosure response, and verify signatures on each signed claim ("verification") included.
-   *
-   * @param     {Object}             response       A selective disclosure response payload, with associated did doc
+   * This function renames and applies special handling to certain recognized key-value pairs, and preserves others
+   * untouched.
+   * 
+   * @private @deprecated
+   * @param     {Object}             response           A selective disclosure response payload, with associated did doc
    * @param     {Object}             response.payload   A selective disclosure response payload, with associated did doc
    * @param     {Object}             response.doc
    */
   async processDisclosurePayload({ doc, payload }) {
-    const credentials = {
-      ...(doc.uportProfile || {}),
-      ...(payload.own || {}),
-      ...(payload.capabilities && payload.capabilities.length === 1 ? { pushToken: payload.capabilities[0] } : {}),
-      did: payload.iss,
-      boxPub: payload.boxPub,
+    console.log('processDisclosurePayload', payload)
+    // Extract known key-value pairs from payload
+    const { own={}, capabilities=[], req, iat, exp, type, nad: mnid, dad: deviceKey, iss: did, boxPub, verified, ...rest } = payload
+    const { uportProfile={} } = doc
+
+    // Combine doc and payload into a single object, changing the names of some keys
+    const processed = {
+      did,
+      boxPub,
+      ...own,
+      ...uportProfile, 
+      ...rest,
     }
-    if (payload.nad) {
-      credentials.mnid = payload.nad
-      credentials.address = mnidDecode(payload.nad).address
+
+    if (mnid) {
+      processed.mnid = mnid
+      processed.address = mnidDecode(mnid).address
     }
-    if (payload.dad) {
-      credentials.deviceKey = payload.dad
+
+    if (deviceKey) {
+      processed.deviceKey = deviceKey
     }
-    if (payload.verified) {
-      const verified = await Promise.all(payload.verified.map(token => verifyJWT(token, { audience: this.did })))
-      return {
-        ...credentials,
-        verified: verified.map(v => ({ ...v.payload, jwt: v.jwt })),
-      }
-    } else {
-      return credentials
+
+    // Push notifications are the only supported capability at the moment
+    if (capabilities.length === 1) {
+      processed.pushToken = capabilities[0]
+    } 
+
+    // Verify and decode each jwt included in the `verified` array, 
+    // and return the verified property as an array of decoded objects
+    if (verified) {
+      processed.verified = (await Promise.all(verified.map(token => verifyJWT(token, { audience: this.did }))))
+        .map(({payload, jwt}) => ({ ...payload, jwt}))
     }
+
+    return processed
   }
 
   /**

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -48,7 +48,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Davie",
+  "name": "Super Developer",
   "phone": "+15555551234",
 }
 `;
@@ -58,7 +58,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Davie",
+  "name": "Super Developer",
   "phone": "+15555551234",
   "verified": Array [
     Object {
@@ -809,7 +809,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Davie",
+  "name": "Bob Smith",
   "phone": "+15555551234",
 }
 `;
@@ -819,7 +819,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
-  "name": "Davie",
+  "name": "Bob Smith",
   "phone": "+15555551234",
   "verified": Array [
     Object {


### PR DESCRIPTION
This slightly changes `Credentials.processDisclosurePayload` to preserve properties of the input payload that aren't recognized to have specific meaning.  Certain expected keys are handled as before, including some who have their names changed in the returned object.

Other semantically relevant JWT keys are dropped, specifically `aud`, `req`, `iat`, and `exp`, and the uPort message `type` field.