### PR TITLE
fix: don't crash on invalid 'verified' jwts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-credentials",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-credentials",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -382,7 +382,13 @@ describe('verifyDisclosure()', () => {
 
     expect(profile.verified.length).toEqual(1)
     expect(profile.invalid.length).toEqual(1)
-    expect(response).toMatchSnapshot()
+    expect(profile).toMatchSnapshot()
+  })
+
+  it('passes through a dad', async () => {
+    const jwt = await uport.createDisclosureResponse({dad: 'hi dad'})
+    const profile = await uport.verifyDisclosure(jwt)
+    expect(profile).toMatchSnapshot()
   })
 })
 

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -372,6 +372,18 @@ describe('verifyDisclosure()', () => {
     const profile = await uport.verifyDisclosure(jwt)
     expect(profile).toMatchSnapshot()
   })
+
+  it('declines to verify invalid jwts without crashing', async () => {
+    const goodjwt = await uport.createVerification(claim)
+    const badjwt = 'not.a.jwt'
+
+    const response = await uport.createDisclosureResponse({verified: [goodjwt, badjwt]})
+    const profile = await uport.verifyDisclosure(response)
+
+    expect(profile.verified.length).toEqual(1)
+    expect(profile.invalid.length).toEqual(1)
+    expect(response).toMatchSnapshot()
+  })
 })
 
 describe('txRequest()', () => {

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -58,6 +58,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "invalid": Array [],
   "name": "Davie",
   "phone": "+15555551234",
   "verified": Array [
@@ -804,6 +805,8 @@ Object {
 }
 `;
 
+exports[`verifyDisclosure() declines to verify invalid jwts without crashing 1`] = `"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidmVyaWZpZWQiOlsiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOa3N0VWlKOS5leUpwWVhRaU9qRTBPRFV6TWpFeE16TXNJbk4xWWlJNklqQjRNVEV5TWpNeklpd2lZMnhoYVcwaU9uc2laVzFoYVd3aU9pSmlhVzVuWW1GdVoySjFibWRBWlcxaGFXd3VZMjl0SW4wc0ltVjRjQ0k2TVRRNE5UTXlNVEV6TkN3aWFYTnpJam9pWkdsa09tVjBhSEk2TUhoaVl6TmhaVFU1WW1NM05tWTRPVFE0TWpJMk1qSmpaR1ZtTjJFeU1ERTRaR0psTXpVek9EUXdJbjAueTdBSzJDWmtDZk1OTTBrMldxQWw3WDdnZzVpZUJSVllhM21ySTNXZnNxM0prSDdtT2Q0SjJYVF83ZUk1R0lMMi10SVZwbnFNV1Z6Q3J2TndSUmt6UVFFIiwibm90LmEuand0Il0sInR5cGUiOiJzaGFyZVJlc3AiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.IXB_YnZ1nyZ1xLqd70JrvRpxO9Dh8DB2Z21zT4qVXLvSKbFfZdb_cbLCRotTBcnDVBs4nIGCrN6P-kLFdLzVawA"`;
+
 exports[`verifyDisclosure() returns profile mixing public and private claims 1`] = `
 Object {
   "boxPub": undefined,
@@ -819,6 +822,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "invalid": Array [],
   "name": "Davie",
   "phone": "+15555551234",
   "verified": Array [

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -805,7 +805,39 @@ Object {
 }
 `;
 
-exports[`verifyDisclosure() declines to verify invalid jwts without crashing 1`] = `"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidmVyaWZpZWQiOlsiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOa3N0VWlKOS5leUpwWVhRaU9qRTBPRFV6TWpFeE16TXNJbk4xWWlJNklqQjRNVEV5TWpNeklpd2lZMnhoYVcwaU9uc2laVzFoYVd3aU9pSmlhVzVuWW1GdVoySjFibWRBWlcxaGFXd3VZMjl0SW4wc0ltVjRjQ0k2TVRRNE5UTXlNVEV6TkN3aWFYTnpJam9pWkdsa09tVjBhSEk2TUhoaVl6TmhaVFU1WW1NM05tWTRPVFE0TWpJMk1qSmpaR1ZtTjJFeU1ERTRaR0psTXpVek9EUXdJbjAueTdBSzJDWmtDZk1OTTBrMldxQWw3WDdnZzVpZUJSVllhM21ySTNXZnNxM0prSDdtT2Q0SjJYVF83ZUk1R0lMMi10SVZwbnFNV1Z6Q3J2TndSUmt6UVFFIiwibm90LmEuand0Il0sInR5cGUiOiJzaGFyZVJlc3AiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.IXB_YnZ1nyZ1xLqd70JrvRpxO9Dh8DB2Z21zT4qVXLvSKbFfZdb_cbLCRotTBcnDVBs4nIGCrN6P-kLFdLzVawA"`;
+exports[`verifyDisclosure() declines to verify invalid jwts without crashing 1`] = `
+Object {
+  "boxPub": undefined,
+  "country": "NI",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "invalid": Array [
+    "not.a.jwt",
+  ],
+  "name": "Bob Smith",
+  "verified": Array [
+    Object {
+      "claim": Object {
+        "email": "bingbangbung@email.com",
+      },
+      "exp": 1485321134,
+      "iat": 1485321133,
+      "iss": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+      "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsInN1YiI6IjB4MTEyMjMzIiwiY2xhaW0iOnsiZW1haWwiOiJiaW5nYmFuZ2J1bmdAZW1haWwuY29tIn0sImV4cCI6MTQ4NTMyMTEzNCwiaXNzIjoiZGlkOmV0aHI6MHhiYzNhZTU5YmM3NmY4OTQ4MjI2MjJjZGVmN2EyMDE4ZGJlMzUzODQwIn0.y7AK2CZkCfMNM0k2WqAl7X7gg5ieBRVYa3mrI3Wfsq3JkH7mOd4J2XT_7eI5GIL2-tIVpnqMWVzCrvNwRRkzQQE",
+      "sub": "0x112233",
+    },
+  ],
+}
+`;
+
+exports[`verifyDisclosure() passes through a dad 1`] = `
+Object {
+  "boxPub": undefined,
+  "country": "NI",
+  "deviceKey": "hi dad",
+  "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "name": "Bob Smith",
+}
+`;
 
 exports[`verifyDisclosure() returns profile mixing public and private claims 1`] = `
 Object {


### PR DESCRIPTION
Previously, if any jwt in the `verified` array was invalid, the verification of the entire disclosure would crash. This adds a new property `invalid` in the returned credentials object from `processDisclosurePayload` which contains all invalid jwts, while the `verified` array contains only those that were successfully verified.

closes #135 