### PR TITLE
fix: don't crash on invalid 'verified' jwts

### DIFF
--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -398,6 +398,18 @@ describe('verifyDisclosure()', () => {
     const profile = await uport.verifyDisclosure(jwt)
     expect(profile).toMatchSnapshot()
   })
+
+  it('declines to verify invalid jwts without crashing', async () => {
+    const goodjwt = await uport.createVerification(claim)
+    const badjwt = 'not.a.jwt'
+
+    const response = await uport.createDisclosureResponse({verified: [goodjwt, badjwt]})
+    const profile = await uport.verifyDisclosure(response)
+
+    expect(profile.verified.length).toEqual(1)
+    expect(profile.invalid.length).toEqual(1)
+    expect(response).toMatchSnapshot()
+  })
 })
 
 describe('txRequest()', () => {

--- a/src/__tests__/__snapshots__/Credentials-test.js.snap
+++ b/src/__tests__/__snapshots__/Credentials-test.js.snap
@@ -58,6 +58,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "invalid": Array [],
   "name": "Super Developer",
   "phone": "+15555551234",
   "verified": Array [
@@ -808,6 +809,8 @@ Object {
 }
 `;
 
+exports[`verifyDisclosure() declines to verify invalid jwts without crashing 1`] = `"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE0ODUzMjExMzMsImV4cCI6MTQ4NTMyMTczMywidmVyaWZpZWQiOlsiZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOa3N0VWlKOS5leUpwWVhRaU9qRTBPRFV6TWpFeE16TXNJbk4xWWlJNklqQjRNVEV5TWpNeklpd2lZMnhoYVcwaU9uc2laVzFoYVd3aU9pSmlhVzVuWW1GdVoySjFibWRBWlcxaGFXd3VZMjl0SW4wc0ltVjRjQ0k2TVRRNE5UTXlNVEV6TkN3aWFYTnpJam9pWkdsa09tVjBhSEk2TUhoaVl6TmhaVFU1WW1NM05tWTRPVFE0TWpJMk1qSmpaR1ZtTjJFeU1ERTRaR0psTXpVek9EUXdJbjAueTdBSzJDWmtDZk1OTTBrMldxQWw3WDdnZzVpZUJSVllhM21ySTNXZnNxM0prSDdtT2Q0SjJYVF83ZUk1R0lMMi10SVZwbnFNV1Z6Q3J2TndSUmt6UVFFIiwibm90LmEuand0Il0sInR5cGUiOiJzaGFyZVJlc3AiLCJpc3MiOiJkaWQ6ZXRocjoweGJjM2FlNTliYzc2Zjg5NDgyMjYyMmNkZWY3YTIwMThkYmUzNTM4NDAifQ.IXB_YnZ1nyZ1xLqd70JrvRpxO9Dh8DB2Z21zT4qVXLvSKbFfZdb_cbLCRotTBcnDVBs4nIGCrN6P-kLFdLzVawA"`;
+
 exports[`verifyDisclosure() returns profile mixing public and private claims 1`] = `
 Object {
   "boxPub": undefined,
@@ -823,6 +826,7 @@ Object {
   "boxPub": undefined,
   "country": "NI",
   "did": "did:ethr:0xbc3ae59bc76f894822622cdef7a2018dbe353840",
+  "invalid": Array [],
   "name": "Bob Smith",
   "phone": "+15555551234",
   "verified": Array [


### PR DESCRIPTION
This cherry-picks #136 onto develop, allowing invalid jwts in the verified array not to crash the verification process.