### PR TITLE
feat: allow exp to be passed to createVerificationSignatureRequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-credentials",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uport-credentials",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Library for interacting with uport profiles and attestations",
   "main": "lib/index.js",
   "files": [

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -21,6 +21,13 @@ const Types = {
 }
 
 /**
+ * Convert a date to seconds since unix epoch, rounded down to the nearest whole second
+ * @param   {Date}   date 
+ * @returns {Number}
+ */
+const toSeconds = date => Math.floor(date / 1000)
+
+/**
  * The Credentials class allows you to easily create the signed payloads used in uPort including
  * credentials and signed mobile app requests (ex. selective disclosure requests
  * for private data). It also provides signature verification over signed payloads.
@@ -238,8 +245,18 @@ class Credentials {
    * @param    {String}      [opts.callbackUrl]  The url to receive the response of this request
    * @returns  {Promise<Object, Error>}          A promise which resolves with a signed JSON Web Token or rejects with an error
    */
-  createVerificationSignatureRequest(unsignedClaim, {aud, sub, riss, callbackUrl} = {}) {
-    return this.signJWT({unsignedClaim, sub, riss, aud, callback: callbackUrl, type: Types.VERIFICATION_SIGNATURE_REQUEST})
+  createVerificationSignatureRequest(unsignedClaim, { aud, sub, riss, callbackUrl, vc, exp } = {}) {
+    // FIXME: did-jwt only accepts expiresIn, and does the reverse of this
+    const expiresIn = exp - toSeconds(Date.now())
+    return this.signJWT({
+      unsignedClaim,
+      sub,
+      riss,
+      aud,
+      vc,
+      callback: callbackUrl,
+      type: Types.VERIFICATION_SIGNATURE_REQUEST,
+    }, expiresIn)
   }
 
   /**

--- a/src/Credentials.js
+++ b/src/Credentials.js
@@ -245,9 +245,7 @@ class Credentials {
    * @param    {String}      [opts.callbackUrl]  The url to receive the response of this request
    * @returns  {Promise<Object, Error>}          A promise which resolves with a signed JSON Web Token or rejects with an error
    */
-  createVerificationSignatureRequest(unsignedClaim, { aud, sub, riss, callbackUrl, vc, exp } = {}) {
-    // FIXME: did-jwt only accepts expiresIn, and does the reverse of this
-    const expiresIn = exp - toSeconds(Date.now())
+  createVerificationSignatureRequest(unsignedClaim, { aud, sub, riss, callbackUrl, vc, expiresIn} = {}) {
     return this.signJWT({
       unsignedClaim,
       sub,

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -5,6 +5,8 @@ import { registerMethod } from 'did-resolver'
 
 MockDate.set(1485321133 * 1000)
 
+const toSeconds = date => Math.floor(date / 1000)
+
 const privateKey = '74894f8853f90e6e3d6dfdd343eb0eb70cca06e552ed8af80adadcc573b35da3'
 const signer = SimpleSigner(privateKey)
 const address = '0xbc3ae59bc76f894822622cdef7a2018dbe353840'
@@ -236,6 +238,13 @@ describe('createVerificationSignatureRequest()', () => {
   it('creates a valid JWT for a request', async () => {
     const jwt = await uport.createVerificationSignatureRequest({claim: { test: {prop1: 1, prop2: 2}}}, {sub: 'did:uport:223ab45'})
     return expect(await verifyJWT(jwt, {audience: did})).toMatchSnapshot()
+  })
+
+  it('allows setting an expiration', async () => {
+    const fakeuport = new Credentials({privateKey, did})
+    // temporarily mock the signJWT method
+    fakeuport.signJWT = (_, expiresIn) => expect(expiresIn).toBeLessThanOrEqual(10)
+    return await uport.createVerificationSignatureRequest({claim: {test: 'test'}}, {exp: toSeconds(Date.now()) + 10 })
   })
 })
 

--- a/src/__tests__/Credentials-test.js
+++ b/src/__tests__/Credentials-test.js
@@ -242,9 +242,10 @@ describe('createVerificationSignatureRequest()', () => {
 
   it('allows setting an expiration', async () => {
     const fakeuport = new Credentials({privateKey, did})
+    const expiresIn = 1000
     // temporarily mock the signJWT method
-    fakeuport.signJWT = (_, expiresIn) => expect(expiresIn).toBeLessThanOrEqual(10)
-    return await uport.createVerificationSignatureRequest({claim: {test: 'test'}}, {exp: toSeconds(Date.now()) + 10 })
+    fakeuport.signJWT = (_, exp) => expect(exp).toEqual(expiresIn)
+    return await uport.createVerificationSignatureRequest({claim: {test: 'test'}}, {expiresIn})
   })
 })
 


### PR DESCRIPTION
This allows a verification signature request to contain an expiration field. Since `did-jwt` expects an `expiresIn` parameter, we must subtract the current time from the provided `exp` field to create the argument to `signJWT`