### PR TITLE
fix: Stop exporting as values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
-import Creds from './Credentials'
-import { SimpleSigner as S } from 'did-jwt'
-import { ContractFactory as CF } from './Contract'
+import Credentials from './Credentials'
+import { SimpleSigner } from 'did-jwt'
+import { ContractFactory } from './Contract'
 
-export const Credentials = Creds
-export const SimpleSigner = S
-export const ContractFactory = CF
-export default { Credentials, SimpleSigner, ContractFactory }
+export { Credentials, SimpleSigner, ContractFactory }


### PR DESCRIPTION
Currently if you use uport-credentials in typescript, you cannot use the exported Credentials class as a type, because it is being exported as a value.

Fixes #176