### PR TITLE
WIP: create VC disclosure request inspired by jolocom-lib

### DIFF
--- a/src/Credentials.ts
+++ b/src/Credentials.ts
@@ -83,10 +83,22 @@ interface ClaimsSpec {
   verifiable: VerifiableClaimsSpec
   user_info?: UserInfoSpec
 }
+declare type Comparable = number | Date;
+interface Constraint {
+  [operator: string]: boolean[] | Array<{
+    var: string;
+  } | string | Comparable>;
+}
+// same as jolocom-lib ICredentialRequest
+interface CredentialRequest {
+  type: string[]
+  constraints: Constraint[]
+}
 interface DisclosureRequestParams {
   claims?: ClaimsSpec
   requested?: string[]
   verified?: string[]
+  requestedCredentials?: CredentialRequest[]
   notifications?: boolean
   callbackUrl?: string
   networkId?: string
@@ -101,6 +113,7 @@ interface DisclosureRequestPayload extends JWTPayload {
   claims?: ClaimsSpec
   requested?: string[]
   verified?: string[]
+  requestedCredentials?: CredentialRequest[]
   permissions?: string[]
   callback?: string
   net?: string
@@ -448,6 +461,7 @@ class Credentials {
     if (params.requested) payload.requested = params.requested
     if (params.verified) payload.verified = params.verified
     if (params.claims) payload.claims = params.claims
+    if (params.requestedCredentials) payload.requestedCredentials = params.requestedCredentials
     if (params.notifications) payload.permissions = ['notifications']
     if (params.callbackUrl) payload.callback = params.callbackUrl
     if (params.networkId) payload.net = params.networkId


### PR DESCRIPTION
do not merge. no tests, no real jolocom-lib compatibility, no response format.

In response to https://github.com/uport-project/uport-credentials/issues/248#issuecomment-674091283 this is how I imagine how one would request one or more jwt-vc from a wallet.

Inspired by the format used by jolocom-lib, see: https://jolocom-lib.readthedocs.io/en/latest/interactionFlows.html#credential-requests . jolocom uses `typ` instead of `type` and as value of `typ`/`type` `credentialRequest` instead of `shareReq` and `callbackURL` instead of `callbackUrl`.